### PR TITLE
Enable some template customization

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -367,7 +367,11 @@ function linktoExternal(longName, name) {
  * @return {string} The HTML for the navigation sidebar.
  */
 function buildNav(members) {
-    var nav = '<h2><a href="/index.html">Stable</a><a href="/indev/index.html">Indev</a></h2>';
+    if (!env.conf.templates.useHomeLink) {
+	var nav = '<h2><a href="/index.html">Stable</a><a href="/indev/index.html">Indev</a></h2>';
+    } else {
+	var nav = '<h2><a href="index.html">Home</a></h2>';
+    }
     var seen = {};
     var seenTutorials = {};
 
@@ -388,7 +392,7 @@ function buildNav(members) {
 		nav += decorators;
 	}
 	nav += buildMemberNav(members.globals.filter(member => member.kind !== 'function'), 'TypeDefs', seen, linkto);
-    // nav += buildMemberNav(members.events, 'Events', seen, linkto);
+    if (env.conf.templates.events) nav += buildMemberNav(members.events, 'Events', seen, linkto);
     nav += buildMemberNav(members.externals, 'Externals', seen, linktoExternal);
 
 


### PR DESCRIPTION
Added some template properties for customization:

- `useHomeLink` - use home link instead of Indev and Stable links
- `events` - show events

_I tested this and it seems to work fine_

![img](https://cl.ly/k35K/Screen%20Shot%202017-04-17%20at%2012.05.55%20PM.png)
![img](https://cl.ly/k36z/Screen%20Shot%202017-04-17%20at%2012.05.32%20PM.png)